### PR TITLE
feat: add MCP registry support with server.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@sperekrestova/interactive-leetcode-mcp",
     "description": "Interactive LeetCode MCP server with authorization and submission capabilities for seamless problem-solving with Claude",
-    "version": "2.0.0",
+    "version": "2.0.1",
+    "mcpName": "io.github.SPerekrestova/interactive-leetcode-mcp",
     "author": "SPerekrestova",
     "main": "./build/index.js",
     "keywords": [

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.SPerekrestova/interactive-leetcode-mcp",
+    "description": "Interactive LeetCode MCP server with authorization and solution submission capabilities",
+    "repository": {
+        "url": "https://github.com/SPerekrestova/interactive-leetcode-mcp",
+        "source": "github"
+    },
+    "version": "2.0.1",
+    "packages": [
+        {
+            "registryType": "npm",
+            "identifier": "@sperekrestova/interactive-leetcode-mcp",
+            "version": "2.0.1",
+            "transport": {
+                "type": "stdio"
+            },
+            "environmentVariables": []
+        }
+    ]
+}


### PR DESCRIPTION
## Overview

Adds MCP registry support to enable publication to the official Model Context Protocol registry.

## Changes

### package.json
- **Added `mcpName`**: `io.github.SPerekrestova/interactive-leetcode-mcp`
  - Required field for MCP registry validation
  - Identifies the server in the registry namespace
- **Version bump**: `2.0.0` → `2.0.1`
  - Patch release to include registry metadata

### server.json (New File)
MCP registry metadata file with:
- **Server identification**: Name, description, repository
- **Package details**: NPM identifier, version, transport type
- **Environment variables**: Empty array (no required env vars)

## MCP Registry Publishing Process

After merging and publishing v2.0.1 to NPM via GitHub Actions:

1. **Authenticate with MCP registry**:
   ```bash
   mcp-publisher login github
   ```

2. **Publish to registry**:
   ```bash
   mcp-publisher publish
   ```

3. **Verify publication**:
   ```bash
   curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.SPerekrestova/interactive-leetcode-mcp"
   ```

## Next Steps

1. Merge this PR
2. Create GitHub release `v2.0.1` (triggers workflow to publish to NPM)
3. Publish to MCP registry using `mcp-publisher` CLI
4. Server will appear at: https://registry.modelcontextprotocol.io/

## Schema Compliance

✅ Follows MCP registry schema v2025-12-11  
✅ Description under 100 character limit  
✅ GitHub username case-sensitive match  
✅ NPM package identifier verified  

🤖 Generated with [Claude Code](https://claude.com/claude-code)