### PR TITLE
chore: bump version to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sperekrestova/interactive-leetcode-mcp",
     "description": "Interactive LeetCode MCP server with authorization and submission capabilities for seamless problem-solving with Claude",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "mcpName": "io.github.SPerekrestova/interactive-leetcode-mcp",
     "author": "SPerekrestova",
     "main": "./build/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
         "url": "https://github.com/SPerekrestova/interactive-leetcode-mcp",
         "source": "github"
     },
-    "version": "3.0.0",
+    "version": "3.1.0",
     "packages": [
         {
             "registryType": "npm",
             "identifier": "@sperekrestova/interactive-leetcode-mcp",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "transport": {
                 "type": "stdio"
             },


### PR DESCRIPTION
## Summary
- Bump version from 3.0.0 to 3.1.0 in `package.json` and `server.json`
- Aligns package version with existing `v3.1.0` git tag

## Changes in 3.1.0 (since v3.0.0)
- **feat**: `get_started` onboarding tool with usage guide
- **feat**: in-memory credential updates after successful auth save
- **refactor**: submission and auth validation moved to service layer
- **refactor**: two-phase registration removed, all tools in `registerPublic()`
- **fix**: cleanup across codebase

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 145 tests pass (`npm test`)
- [x] Version synced across `package.json` and `server.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)