### PR TITLE
Add local MCP dogfood testing workflow

### DIFF
--- a/DOGFOOD_TESTING.md
+++ b/DOGFOOD_TESTING.md
@@ -1,0 +1,122 @@
+# Dogfood testing the MCP as a user
+
+This repo has two ways to test the server like an MCP client would:
+
+1. `npm run dogfood:local` — deterministic black-box smoke test with mocked
+   LeetCode HTTP.
+2. A local-agent prompt — ask Claude Code/another MCP-capable agent to use the
+   local build as a real user would.
+
+## Option 1: deterministic local dogfood
+
+```bash
+npm install
+npm run dogfood:local
+```
+
+The script:
+
+- builds `build/index.js`,
+- spawns the built MCP server over stdio,
+- connects with `@modelcontextprotocol/sdk`'s `StdioClientTransport`,
+- gives the server an isolated temporary `HOME`,
+- preloads the same `nock` fixture harness used by e2e tests, so it never
+  reaches live `leetcode.com`,
+- calls tools in a user-like sequence:
+  - `listTools`
+  - `runner_doctor`
+  - `start_problem`
+  - `request_hint`
+  - `run_local_tests` for each locally available runtime (`python3`, `go`,
+    `java`)
+  - `get_session_state`
+
+Set `DOGFOOD_KEEP_HOME=1` if you want to inspect the isolated session directory
+after a run:
+
+```bash
+DOGFOOD_KEEP_HOME=1 npm run dogfood:local
+```
+
+This is the fastest path for Devin or CI-like environments because it needs no
+LeetCode credentials and is stable even when LeetCode is down.
+
+## Option 2: local Claude/agent dogfood
+
+First build the server:
+
+```bash
+npm install
+npm run build
+```
+
+Then point the local agent at the build:
+
+```bash
+claude mcp add --transport stdio leetcode-local -- node /absolute/path/to/interactive-leetcode-mcp/build/index.js
+```
+
+If your agent uses an MCP JSON config instead, add:
+
+```json
+{
+  "mcpServers": {
+    "leetcode-local": {
+      "command": "node",
+      "args": ["/absolute/path/to/interactive-leetcode-mcp/build/index.js"]
+    }
+  }
+}
+```
+
+Use this prompt with the local agent:
+
+```text
+You are dogfood-testing the local interactive-leetcode-mcp server as if you were
+a user practicing a problem with an MCP-aware coding agent.
+
+Rules:
+- Use only the MCP server named `leetcode-local`.
+- Do not assume LeetCode credentials are present.
+- If auth is missing, do not block: skip live submit/profile checks and continue
+  with unauthenticated problem/session/local-runner checks.
+- Report a concise transcript of every MCP tool call, arguments, and important
+  result fields.
+- Treat tool errors as findings only after explaining which call produced them.
+
+Test plan:
+1. List available MCP tools and confirm these exist:
+   `start_problem`, `request_hint`, `get_session_state`, `runner_doctor`,
+   `run_local_tests`, `submit_solution`.
+2. Call `runner_doctor` and record which runtimes are available for
+   `python3`, `go`, and `java`.
+3. Call `get_problem` for `two-sum`. Summarize the title, difficulty, tags, and
+   starter snippets.
+4. Call `start_problem` for `two-sum` in `python3`.
+5. Call `request_hint` once and confirm the session hint level advanced.
+6. Call `run_local_tests` with an intentionally failing Python snippet and
+   confirm the result is a non-passing local run, not a transport failure.
+7. Call `run_local_tests` again with a passing Python snippet:
+   `print("dogfood ok"); assert 1 + 1 == 2`
+8. Call `get_session_state` and confirm attempts incremented and
+   `lastLocalRunPassed` reflects the most recent passing run.
+9. If `go` or `java` are available in `runner_doctor`, repeat one passing
+   `run_local_tests` call for each available runtime using a complete program
+   with a `main`.
+10. If authenticated and strict mode is enabled, explain whether
+    `submit_solution` would be allowed for the exact code/language snapshot. Do
+    not spend a real LeetCode submission unless explicitly approved.
+
+Return:
+- PASS/FAIL for each step.
+- Runtime availability table.
+- Any actionable bugs or confusing tool output.
+- Exact repro commands/tool calls for failures.
+```
+
+## When to use which
+
+- Use `npm run dogfood:local` before PRs and in Devin sessions. It is
+  deterministic and does not need secrets.
+- Use the local-agent prompt when validating real client behavior, local MCP
+  configuration, auth flows, or live LeetCode integration.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,22 @@ To activate learning mode, tell Claude you want to practice with guidance — fo
 3. **Implement your solution** with progressive guidance
 4. **Request the solution** only when you want to compare with optimal approach ("Show me the solution")
 
+## Dogfood Testing
+
+To test the MCP server as a black-box MCP client without live LeetCode traffic:
+
+```bash
+npm run dogfood:local
+```
+
+This builds the server, spawns `build/index.js` over stdio, connects with the
+MCP SDK client, uses an isolated `HOME`, serves LeetCode responses from fixtures,
+and drives a user-like flow through `runner_doctor`, `start_problem`,
+`request_hint`, `run_local_tests`, and `get_session_state`.
+
+See [DOGFOOD_TESTING.md](DOGFOOD_TESTING.md) for the full workflow and a
+copy-paste prompt for local Claude/agent dogfood testing.
+
 ## Troubleshooting
 
 **"Not authorized" or "Invalid credentials" error**

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "test:integration": "vitest run tests/integration",
         "test:e2e": "vitest run --config vitest.e2e.config.ts",
         "test:all": "npm run test && npm run test:e2e",
+        "dogfood:local": "npm run build && tsx scripts/dogfood-local.ts",
         "test:coverage": "vitest run --exclude 'tests/e2e/**' --coverage",
         "test:watch": "vitest watch",
         "test:types": "tsc -p tsconfig.test.json",

--- a/scripts/dogfood-local.ts
+++ b/scripts/dogfood-local.ts
@@ -175,30 +175,40 @@ async function spawnDogfoodServer(): Promise<SpawnedDogfoodServer> {
         args: [SERVER_BIN],
         env,
         cwd: REPO_ROOT,
-        stderr: "pipe"
+        stderr: "inherit"
     });
 
     const client = new Client({
         name: "leetcode-mcp-dogfood",
         version: "0.0.0"
     });
-    await client.connect(transport);
+
+    const cleanup = async () => {
+        try {
+            await client.close();
+        } catch {
+            // A failed connect may leave the client half-open; cleanup should continue.
+        } finally {
+            if (process.env.DOGFOOD_KEEP_HOME === "1") {
+                console.log(`Keeping dogfood HOME for inspection: ${home}`);
+            } else {
+                await rm(home, { recursive: true, force: true });
+            }
+            await rm(fixtureDir, { recursive: true, force: true });
+        }
+    };
+
+    try {
+        await client.connect(transport);
+    } catch (error) {
+        await cleanup();
+        throw error;
+    }
 
     return {
         client,
         home,
-        cleanup: async () => {
-            try {
-                await client.close();
-            } finally {
-                if (process.env.DOGFOOD_KEEP_HOME === "1") {
-                    console.log(`Keeping dogfood HOME for inspection: ${home}`);
-                } else {
-                    await rm(home, { recursive: true, force: true });
-                }
-                await rm(fixtureDir, { recursive: true, force: true });
-            }
-        }
+        cleanup
     };
 }
 

--- a/scripts/dogfood-local.ts
+++ b/scripts/dogfood-local.ts
@@ -1,0 +1,310 @@
+#!/usr/bin/env tsx
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { constants } from "node:fs";
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+type JsonObject = Record<string, unknown>;
+type RunnerLanguage = "python3" | "go" | "java";
+
+interface SpawnedDogfoodServer {
+    client: Client;
+    home: string;
+    cleanup(): Promise<void>;
+}
+
+interface RunnerSmoke {
+    language: RunnerLanguage;
+    marker: string;
+    code: string;
+    timeoutMs?: number;
+}
+
+const SCRIPT_DIR = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const SERVER_BIN = join(REPO_ROOT, "build", "index.js");
+const PRELOAD = join(REPO_ROOT, "tests", "e2e", "harness", "preload.mjs");
+
+const TWO_SUM_PROBLEM = {
+    questionId: "1",
+    questionFrontendId: "1",
+    title: "Two Sum",
+    titleSlug: "two-sum",
+    difficulty: "Easy",
+    isPaidOnly: false,
+    content:
+        "<p>Given an array of integers <code>nums</code> and an integer <code>target</code>, return indices of the two numbers.</p>",
+    topicTags: [{ name: "Array", slug: "array" }],
+    codeSnippets: [
+        {
+            lang: "Python3",
+            langSlug: "python3",
+            code: "class Solution:\n    def twoSum(self, nums, target):\n        pass\n"
+        },
+        {
+            lang: "Go",
+            langSlug: "go",
+            code: "package main\n\nfunc main() {}\n"
+        },
+        {
+            lang: "Java",
+            langSlug: "java",
+            code: "public class Solution {\n    public static void main(String[] args) {}\n}\n"
+        }
+    ],
+    similarQuestions: "[]",
+    exampleTestcases: "[2,7,11,15]\n9",
+    hints: ["Try storing previously seen numbers in a hash map."],
+    stats: '{"totalAccepted":"10M","totalSubmission":"20M","acRate":"50.0%"}'
+};
+
+const FIXTURE = {
+    graphql: [
+        {
+            operationContains: "question(titleSlug:",
+            response: { data: { question: TWO_SUM_PROBLEM } }
+        }
+    ]
+};
+
+const RUNNER_SMOKES: RunnerSmoke[] = [
+    {
+        language: "python3",
+        marker: "python ok",
+        code: 'print("python ok")\nassert 1 + 1 == 2'
+    },
+    {
+        language: "go",
+        marker: "go ok",
+        timeoutMs: 20_000,
+        code: [
+            "package main",
+            'import "fmt"',
+            "func main() {",
+            '    fmt.Println("go ok")',
+            '    if 1 + 1 != 2 { panic("bad math") }',
+            "}"
+        ].join("\n")
+    },
+    {
+        language: "java",
+        marker: "java ok",
+        timeoutMs: 20_000,
+        code: [
+            "public class Solution {",
+            "    public static void main(String[] args) {",
+            '        System.out.println("java ok");',
+            '        if (1 + 1 != 2) { throw new RuntimeException("bad math"); }',
+            "    }",
+            "}"
+        ].join("\n")
+    }
+];
+
+function isJsonObject(value: unknown): value is JsonObject {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseToolText(result: unknown, toolName: string): JsonObject {
+    if (!isJsonObject(result) || !Array.isArray(result.content)) {
+        throw new Error(`${toolName} returned a non-standard MCP result`);
+    }
+
+    const first = result.content[0];
+    if (!isJsonObject(first) || first.type !== "text") {
+        throw new Error(`${toolName} did not return text content`);
+    }
+
+    const text = first.text;
+    if (typeof text !== "string") {
+        throw new Error(`${toolName} text content was not a string`);
+    }
+
+    const parsed: unknown = JSON.parse(text);
+    if (!isJsonObject(parsed)) {
+        throw new Error(`${toolName} returned non-object JSON`);
+    }
+    return parsed;
+}
+
+async function callToolJson(
+    client: Client,
+    name: string,
+    args: JsonObject
+): Promise<JsonObject> {
+    const result = await client.callTool({ name, arguments: args });
+    return parseToolText(result, name);
+}
+
+async function assertBuiltServerExists(): Promise<void> {
+    try {
+        await access(SERVER_BIN, constants.X_OK);
+    } catch {
+        throw new Error(
+            `Built server not found at ${SERVER_BIN}. Run "npm run build" first.`
+        );
+    }
+}
+
+async function spawnDogfoodServer(): Promise<SpawnedDogfoodServer> {
+    await assertBuiltServerExists();
+
+    const home = await mkdtemp(join(tmpdir(), "leetcode-mcp-dogfood-home-"));
+    const fixtureDir = await mkdtemp(
+        join(tmpdir(), "leetcode-mcp-dogfood-fixture-")
+    );
+    const fixturePath = join(fixtureDir, "fixture.json");
+    await writeFile(fixturePath, JSON.stringify(FIXTURE), "utf-8");
+
+    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
+    const preloadOption = `--import ${pathToFileURL(PRELOAD).href}`;
+    const env: Record<string, string> = {
+        PATH: process.env.PATH ?? "",
+        HOME: home,
+        NODE_OPTIONS: existingNodeOptions
+            ? `${existingNodeOptions} ${preloadOption}`
+            : preloadOption,
+        E2E_FIXTURE_PATH: fixturePath
+    };
+
+    const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: [SERVER_BIN],
+        env,
+        cwd: REPO_ROOT,
+        stderr: "pipe"
+    });
+
+    const client = new Client({
+        name: "leetcode-mcp-dogfood",
+        version: "0.0.0"
+    });
+    await client.connect(transport);
+
+    return {
+        client,
+        home,
+        cleanup: async () => {
+            try {
+                await client.close();
+            } finally {
+                if (process.env.DOGFOOD_KEEP_HOME === "1") {
+                    console.log(`Keeping dogfood HOME for inspection: ${home}`);
+                } else {
+                    await rm(home, { recursive: true, force: true });
+                }
+                await rm(fixtureDir, { recursive: true, force: true });
+            }
+        }
+    };
+}
+
+function languageAvailable(
+    doctor: JsonObject,
+    language: RunnerLanguage
+): boolean {
+    const languages = doctor.languages;
+    if (!Array.isArray(languages)) {
+        return false;
+    }
+
+    const entry = languages.find(
+        (item) => isJsonObject(item) && item.language === language
+    );
+    return isJsonObject(entry) && entry.available === true;
+}
+
+function assertRunPassed(payload: JsonObject, smoke: RunnerSmoke): void {
+    const result = payload.result;
+    if (!isJsonObject(result)) {
+        throw new Error(`${smoke.language} run_local_tests returned no result`);
+    }
+    if (result.passed !== true || result.exitCode !== 0) {
+        throw new Error(
+            `${smoke.language} run_local_tests failed: ${JSON.stringify(result)}`
+        );
+    }
+    if (
+        typeof result.stdout !== "string" ||
+        !result.stdout.includes(smoke.marker)
+    ) {
+        throw new Error(
+            `${smoke.language} stdout did not include ${JSON.stringify(
+                smoke.marker
+            )}: ${JSON.stringify(result.stdout)}`
+        );
+    }
+}
+
+async function main(): Promise<void> {
+    const spawned = await spawnDogfoodServer();
+    try {
+        console.log("Dogfood MCP smoke: spawned build/index.js over stdio");
+        console.log(`Isolated HOME: ${spawned.home}`);
+
+        const tools = await spawned.client.listTools();
+        console.log(`MCP listTools returned ${tools.tools.length} tools`);
+
+        const doctor = await callToolJson(spawned.client, "runner_doctor", {});
+        console.log("Agent> runner_doctor");
+        console.log(JSON.stringify(doctor, null, 2));
+
+        const start = await callToolJson(spawned.client, "start_problem", {
+            titleSlug: "two-sum",
+            language: "python3"
+        });
+        console.log(
+            `Agent> start_problem(two-sum) => session status ${String(
+                isJsonObject(start.session) ? start.session.status : "unknown"
+            )}`
+        );
+
+        const hint = await callToolJson(spawned.client, "request_hint", {
+            titleSlug: "two-sum"
+        });
+        console.log(
+            `Agent> request_hint(two-sum) => level ${String(hint.level)}`
+        );
+
+        for (const smoke of RUNNER_SMOKES) {
+            if (!languageAvailable(doctor, smoke.language)) {
+                console.log(
+                    `Agent> run_local_tests(${smoke.language}) skipped: runtime unavailable`
+                );
+                continue;
+            }
+
+            const payload = await callToolJson(
+                spawned.client,
+                "run_local_tests",
+                {
+                    titleSlug: "two-sum",
+                    language: smoke.language,
+                    code: smoke.code,
+                    timeoutMs: smoke.timeoutMs
+                }
+            );
+            assertRunPassed(payload, smoke);
+            console.log(`Agent> run_local_tests(${smoke.language}) passed`);
+        }
+
+        const state = await callToolJson(spawned.client, "get_session_state", {
+            titleSlug: "two-sum"
+        });
+        console.log("Agent> get_session_state(two-sum)");
+        console.log(JSON.stringify(state, null, 2));
+
+        console.log("Dogfood MCP smoke completed successfully");
+    } finally {
+        await spawned.cleanup();
+    }
+}
+
+main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.stack : String(error);
+    console.error(message);
+    process.exitCode = 1;
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,5 +4,5 @@
         "rootDir": ".",
         "noEmit": true
     },
-    "include": ["src/**/*", "tests/**/*"]
+    "include": ["src/**/*", "tests/**/*", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
Adds a deterministic dogfood path that runs the built MCP server exactly like a client would: `npm run dogfood:local` builds `build/index.js`, spawns it over stdio with `StdioClientTransport`, injects the existing e2e `nock` preload fixture, isolates `HOME`, and drives a user-like flow through:

```text
listTools → runner_doctor → start_problem → request_hint → run_local_tests → get_session_state
```

The smoke covers available local runners (`python3`, `go`, `java`) without requiring LeetCode credentials or live network access, so Devin/CI-like environments can validate the MCP behavior directly. It also documents a second path for a real local Claude/agent setup, including the MCP config command and a copy-paste prompt for testing the server as a practicing user while avoiding accidental live submissions.

Verified locally with `npm run build`, `npm run test:types`, `npx prettier --check .`, `npm run dogfood:local`, `npm test`, and `npm run test:e2e`.

Link to Devin session: https://app.devin.ai/sessions/3e6f3e63f6e54852b9bf6da1c792774f
Requested by: @SPerekrestova