### PR TITLE
Fix Hono Dependabot security alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3238,9 +3238,9 @@
             "license": "MIT"
         },
         "node_modules/hono": {
-            "version": "4.12.23",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-            "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+            "version": "4.12.26",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+            "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"


### PR DESCRIPTION
## Summary
Updates the lockfile resolution for transitive `hono` from `4.12.23` to `4.12.26`, clearing the Dependabot/npm audit advisories for `<4.12.25` while leaving package manifests unchanged.

Verification:
- `npm audit` → 0 vulnerabilities
- `npm run test:types`
- `npm run build`
- `npm test`
- `npm run test:e2e`
- `npx prettier --check .`
- `npx eslint src tests eslint.config.js vitest.config.ts vitest.e2e.config.ts`
- CI passed on PR #51

Link to Devin session: https://app.devin.ai/sessions/b5ab64b5a3194630bdf133c4815f1aee
Requested by: @SPerekrestova