### PR TITLE
Release v3.2.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
                 "repo": "SPerekrestova/interactive-leetcode-mcp"
             },
             "description": "Interactive LeetCode practice with learning-guided hints, solution submission, and AI-driven authentication via MCP server",
-            "version": "3.2.0",
+            "version": "3.2.3",
             "homepage": "https://github.com/SPerekrestova/interactive-leetcode-mcp",
             "keywords": ["leetcode", "mcp", "practice", "coding-interview"],
             "category": "learning"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
                 "repo": "SPerekrestova/interactive-leetcode-mcp"
             },
             "description": "Interactive LeetCode practice with learning-guided hints, solution submission, and AI-driven authentication via MCP server",
-            "version": "3.2.3",
+            "version": "3.2.4",
             "homepage": "https://github.com/SPerekrestova/interactive-leetcode-mcp",
             "keywords": ["leetcode", "mcp", "practice", "coding-interview"],
             "category": "learning"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "interactive-leetcode-mcp",
     "description": "Interactive LeetCode practice with learning-guided hints, solution submission, and AI-driven authentication via MCP server",
-    "version": "3.2.0",
+    "version": "3.2.3",
     "author": {
         "name": "SPerekrestova"
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "interactive-leetcode-mcp",
     "description": "Interactive LeetCode practice with learning-guided hints, solution submission, and AI-driven authentication via MCP server",
-    "version": "3.2.3",
+    "version": "3.2.4",
     "author": {
         "name": "SPerekrestova"
     },

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set version from tag
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          npm version "$VERSION" --no-git-tag-version
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
           npm run sync-version
 
       - run: npm ci

--- a/clawhub-skill/interactive-leetcode-mcp/SKILL.md
+++ b/clawhub-skill/interactive-leetcode-mcp/SKILL.md
@@ -33,7 +33,7 @@ After the user confirms, add to the client's MCP configuration (the exact file v
   "mcpServers": {
     "leetcode": {
       "command": "npx",
-      "args": ["-y", "@sperekrestova/interactive-leetcode-mcp@3.2.3"]
+      "args": ["-y", "@sperekrestova/interactive-leetcode-mcp@3.2.4"]
     }
   }
 }
@@ -42,7 +42,7 @@ After the user confirms, add to the client's MCP configuration (the exact file v
 For Claude Code specifically, you can also run:
 
 ```bash
-claude mcp add --transport stdio leetcode -- npx -y @sperekrestova/interactive-leetcode-mcp@3.2.3
+claude mcp add --transport stdio leetcode -- npx -y @sperekrestova/interactive-leetcode-mcp@3.2.4
 ```
 
 **Pin a specific version** (shown above) rather than using `@latest` to avoid executing untested code. Users can check for newer versions at the [npm page](https://www.npmjs.com/package/@sperekrestova/interactive-leetcode-mcp) or [GitHub releases](https://github.com/SPerekrestova/interactive-leetcode-mcp/releases) and update the pinned version after reviewing the changelog.

--- a/clawhub-skill/interactive-leetcode-mcp/SKILL.md
+++ b/clawhub-skill/interactive-leetcode-mcp/SKILL.md
@@ -33,7 +33,7 @@ After the user confirms, add to the client's MCP configuration (the exact file v
   "mcpServers": {
     "leetcode": {
       "command": "npx",
-      "args": ["-y", "@sperekrestova/interactive-leetcode-mcp@3.2.0"]
+      "args": ["-y", "@sperekrestova/interactive-leetcode-mcp@3.2.3"]
     }
   }
 }
@@ -42,7 +42,7 @@ After the user confirms, add to the client's MCP configuration (the exact file v
 For Claude Code specifically, you can also run:
 
 ```bash
-claude mcp add --transport stdio leetcode -- npx -y @sperekrestova/interactive-leetcode-mcp@3.2.0
+claude mcp add --transport stdio leetcode -- npx -y @sperekrestova/interactive-leetcode-mcp@3.2.3
 ```
 
 **Pin a specific version** (shown above) rather than using `@latest` to avoid executing untested code. Users can check for newer versions at the [npm page](https://www.npmjs.com/package/@sperekrestova/interactive-leetcode-mcp) or [GitHub releases](https://github.com/SPerekrestova/interactive-leetcode-mcp/releases) and update the pinned version after reviewing the changelog.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@sperekrestova/interactive-leetcode-mcp",
-    "version": "3.2.3",
+    "version": "3.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@sperekrestova/interactive-leetcode-mcp",
-            "version": "3.2.3",
+            "version": "3.2.4",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@sperekrestova/interactive-leetcode-mcp",
-    "version": "3.2.0",
+    "version": "3.2.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@sperekrestova/interactive-leetcode-mcp",
-            "version": "3.2.0",
+            "version": "3.2.3",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sperekrestova/interactive-leetcode-mcp",
     "description": "Interactive LeetCode MCP server with authorization and submission capabilities for seamless problem-solving with Claude",
-    "version": "3.2.3",
+    "version": "3.2.4",
     "mcpName": "io.github.SPerekrestova/interactive-leetcode-mcp",
     "author": "SPerekrestova",
     "main": "./build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sperekrestova/interactive-leetcode-mcp",
     "description": "Interactive LeetCode MCP server with authorization and submission capabilities for seamless problem-solving with Claude",
-    "version": "3.2.0",
+    "version": "3.2.3",
     "mcpName": "io.github.SPerekrestova/interactive-leetcode-mcp",
     "author": "SPerekrestova",
     "main": "./build/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
         "url": "https://github.com/SPerekrestova/interactive-leetcode-mcp",
         "source": "github"
     },
-    "version": "3.2.3",
+    "version": "3.2.4",
     "packages": [
         {
             "registryType": "npm",
             "identifier": "@sperekrestova/interactive-leetcode-mcp",
-            "version": "3.2.3",
+            "version": "3.2.4",
             "transport": {
                 "type": "stdio"
             },

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
         "url": "https://github.com/SPerekrestova/interactive-leetcode-mcp",
         "source": "github"
     },
-    "version": "3.2.0",
+    "version": "3.2.3",
     "packages": [
         {
             "registryType": "npm",
             "identifier": "@sperekrestova/interactive-leetcode-mcp",
-            "version": "3.2.0",
+            "version": "3.2.3",
             "transport": {
                 "type": "stdio"
             },

--- a/skills/interactive-leetcode-mcp/SKILL.md
+++ b/skills/interactive-leetcode-mcp/SKILL.md
@@ -24,7 +24,7 @@ After the user confirms, add to the client's MCP configuration (the exact file v
   "mcpServers": {
     "leetcode": {
       "command": "npx",
-      "args": ["-y", "@sperekrestova/interactive-leetcode-mcp@3.2.0"]
+      "args": ["-y", "@sperekrestova/interactive-leetcode-mcp@3.2.3"]
     }
   }
 }
@@ -33,7 +33,7 @@ After the user confirms, add to the client's MCP configuration (the exact file v
 For Claude Code specifically, you can also run:
 
 ```bash
-claude mcp add --transport stdio leetcode -- npx -y @sperekrestova/interactive-leetcode-mcp@3.2.0
+claude mcp add --transport stdio leetcode -- npx -y @sperekrestova/interactive-leetcode-mcp@3.2.3
 ```
 
 **Pin a specific version** (shown above) rather than using `@latest` to avoid executing untested code. Users can check for newer versions at the [npm page](https://www.npmjs.com/package/@sperekrestova/interactive-leetcode-mcp) or [GitHub releases](https://github.com/SPerekrestova/interactive-leetcode-mcp/releases) and update the pinned version after reviewing the changelog.

--- a/skills/interactive-leetcode-mcp/SKILL.md
+++ b/skills/interactive-leetcode-mcp/SKILL.md
@@ -24,7 +24,7 @@ After the user confirms, add to the client's MCP configuration (the exact file v
   "mcpServers": {
     "leetcode": {
       "command": "npx",
-      "args": ["-y", "@sperekrestova/interactive-leetcode-mcp@3.2.3"]
+      "args": ["-y", "@sperekrestova/interactive-leetcode-mcp@3.2.4"]
     }
   }
 }
@@ -33,7 +33,7 @@ After the user confirms, add to the client's MCP configuration (the exact file v
 For Claude Code specifically, you can also run:
 
 ```bash
-claude mcp add --transport stdio leetcode -- npx -y @sperekrestova/interactive-leetcode-mcp@3.2.3
+claude mcp add --transport stdio leetcode -- npx -y @sperekrestova/interactive-leetcode-mcp@3.2.4
 ```
 
 **Pin a specific version** (shown above) rather than using `@latest` to avoid executing untested code. Users can check for newer versions at the [npm page](https://www.npmjs.com/package/@sperekrestova/interactive-leetcode-mcp) or [GitHub releases](https://github.com/SPerekrestova/interactive-leetcode-mcp/releases) and update the pinned version after reviewing the changelog.


### PR DESCRIPTION
## Summary
Prepares `v3.2.4` as the next patch release because npm `latest` is already `3.2.2`, and the first attempted `v3.2.3` tag exposed a publish workflow idempotency issue before anything reached npm.

This keeps all release surfaces aligned before publishing:

```text
package.json / package-lock.json / server.json / Claude plugin manifests / MCP skills
3.2.0 -> 3.2.4
```

Release focus: ship the merged Hono security patch from PR #51 so new installs resolve the non-vulnerable lockfile metadata and pinned setup instructions reference the new package version.

Also hardens `publish.yml` so tag-triggered releases do not fail when the tagged commit already has the release version in `package.json` (`npm version --allow-same-version`).

Local release verification:
- `npm run sync-version`
- `npx prettier --check .`
- `npm audit` → 0 vulnerabilities
- `npm run test:types`
- `npm run build`
- `npm test`
- `npm run test:e2e`
- `npm pack --dry-run`

Link to Devin session: https://app.devin.ai/sessions/b5ab64b5a3194630bdf133c4815f1aee
Requested by: @SPerekrestova